### PR TITLE
WIP: create docker image for compiling stan into wasm

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,6 +46,8 @@ no released version will work with Stan and Emscripten, so commit `4a87ca1` or n
    ```makefile
    %.js : %.o $(TINYSTAN_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
 	$(LINK.cpp) -lm -o $(patsubst %.o, %.js, $(subst \,/,$<)) $(subst \,/,$*.o) $(TINYSTAN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
+   %.js : %.o $(TINYSTAN_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
+   $(LINK.cpp) -lm -o $(patsubst %.o, %.js, $(subst \,/,$<)) $(subst \,/,$*.o) $(TINYSTAN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
    ```
    And then running `emmake make test_models/bernoulli/bernoulli.js -j2`
 7. Copy `test_models/bernoulli/bernoulli.js` and `test_models/bernoulli/bernoulli.wasm` to `src/tinystan`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,7 @@ and `bernoulli.wasm` files in `src/tinystan`.
 The following steps should get you up and running:
 
 1. Install the [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html)
-2. Download a copy of [TinyStan](https://github.com/WardBrian/tinystan) (C-wrappers around Stan's C++ interfaces)
+2. Download a copy of [TinyStan](https://github.com/WardBrian/tinystan) (C-wrappers around Stan's C++ interfaces). Clone the repository using the --recursive flag in order to get the submodules.
 3. Download a recent version of [Intel's oneTBB library](https://github.com/oneapi-src/oneTBB). At the time of writing,
 no released version will work with Stan and Emscripten, so commit `4a87ca1` or newer must be used. This is expected to be in the next release
 (either `2021.12.1` or `2021.13.0`)
@@ -39,7 +39,7 @@ no released version will work with Stan and Emscripten, so commit `4a87ca1` or n
    EXPORTS=_malloc,_free,_tinystan_api_version,_tinystan_create_model,_tinystan_destroy_error,_tinystan_destroy_model,_tinystan_get_error_message,_tinystan_get_error_type,_tinystan_model_num_free_params,_tinystan_model_param_names,_tinystan_sample,_tinystan_separator_char,_tinystan_stan_version
    CXXFLAGS+=-fwasm-exceptions # could also uses -fexceptions which is more compatible, but slower
    CXXFLAGS+=-sEXIT_RUNTIME=1 -sALLOW_MEMORY_GROWTH=1
-   CXXFLAGS+=-sEXPORTED_FUNCTIONS=$(EXPORTS)-sEXPORTED_RUNTIME_METHODS=stringToUTF8,getValue,UTF8ToString,lengthBytesUTF8
+   CXXFLAGS+=-sEXPORTED_FUNCTIONS=$(EXPORTS) -sEXPORTED_RUNTIME_METHODS=stringToUTF8,getValue,UTF8ToString,lengthBytesUTF8
    CXXFLAGS+=-sMODULARIZE -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web
    ```
 6. Build the model. The easiest way to do this is currently to add this snippet to the bottom of the TinyStan `Makefile`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     make
 
 # Clone the TinyStan repository
-RUN git clone https://github.com/WardBrian/tinystan.git
+RUN git clone --recursive https://github.com/WardBrian/tinystan.git
 
 # Clone the oneTBB library and checkout the specific commit
 RUN git clone https://github.com/oneapi-src/oneTBB.git && \
@@ -38,8 +38,9 @@ COPY make/local /app/tinystan/make/local
 # Build the model
 RUN cd tinystan && \
     echo "\n%.js : %.o \$(TINYSTAN_O) \$(SUNDIALS_TARGETS) \$(MPI_TARGETS) \$(TBB_TARGETS)\n\t\$(LINK.cpp) -lm -o \$(patsubst %.o, %.js, \$(subst \\,/,\$<)) \$(subst \\,/,\$*.o) \$(TINYSTAN_O) \$(LDLIBS) \$(SUNDIALS_TARGETS) \$(MPI_TARGETS) \$(TBB_TARGETS)" >> Makefile
-    # emmake make test_models/bernoulli/bernoulli.js -j2
 
-# # Copy the built files to the desired location
-# RUN cp tinystan/test_models/bernoulli/bernoulli.js src/tinystan && \
-#     cp tinystan/test_models/bernoulli/bernoulli.wasm src/tinystan
+RUN cd tinystan && emmake make test_models/bernoulli/bernoulli.js -j2
+
+# Copy the built files to the desired location
+RUN cp tinystan/test_models/bernoulli/bernoulli.js src/tinystan && \
+    cp tinystan/test_models/bernoulli/bernoulli.wasm src/tinystan

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,9 +37,9 @@ COPY make/local /app/tinystan/make/local
 
 # Build the model
 RUN cd tinystan && \
-    echo "\n%.js : %.o $(TINYSTAN_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)\n\t$(LINK.cpp) -lm -o $(patsubst %.o, %.js, $(subst \\,/,$<)) $(subst \\,/,$*.o) $(TINYSTAN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)" >> Makefile && \
-    emmake make test_models/bernoulli/bernoulli.js -j2
+    echo "\n%.js : %.o \$(TINYSTAN_O) \$(SUNDIALS_TARGETS) \$(MPI_TARGETS) \$(TBB_TARGETS)\n\t\$(LINK.cpp) -lm -o \$(patsubst %.o, %.js, \$(subst \\,/,\$<)) \$(subst \\,/,\$*.o) \$(TINYSTAN_O) \$(LDLIBS) \$(SUNDIALS_TARGETS) \$(MPI_TARGETS) \$(TBB_TARGETS)" >> Makefile
+    # emmake make test_models/bernoulli/bernoulli.js -j2
 
-# Copy the built files to the desired location
-RUN cp tinystan/test_models/bernoulli/bernoulli.js src/tinystan && \
-    cp tinystan/test_models/bernoulli/bernoulli.wasm src/tinystan
+# # Copy the built files to the desired location
+# RUN cp tinystan/test_models/bernoulli/bernoulli.js src/tinystan && \
+#     cp tinystan/test_models/bernoulli/bernoulli.wasm src/tinystan

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,6 +41,6 @@ RUN cd tinystan && \
 
 RUN cd tinystan && emmake make test_models/bernoulli/bernoulli.js -j2
 
-# Copy the built files to the desired location
-RUN cp tinystan/test_models/bernoulli/bernoulli.js src/tinystan && \
-    cp tinystan/test_models/bernoulli/bernoulli.wasm src/tinystan
+# # Copy the built files to the desired location
+# RUN cp tinystan/test_models/bernoulli/bernoulli.js src/tinystan && \
+#     cp tinystan/test_models/bernoulli/bernoulli.wasm src/tinystan

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,15 +20,15 @@ RUN git clone https://github.com/oneapi-src/oneTBB.git && \
 
 # Build oneTBB with emscripten
 RUN mkdir oneTBB/build && cd oneTBB/build && \
-    emcmake cmake .. && \
-    -DCMAKE_CXX_COMPILER=em++ && \
-    -DCMAKE_C_COMPILER=emcc && \
-    -DTBB_STRICT=OFF && \
-    -DCMAKE_CXX_FLAGS="-fwasm-exceptions -Wno-unused-command-line-argument" && \
-    -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON && \
-    -DBUILD_SHARED_LIBS=ON && \
-    -DTBB_EXAMPLES=OFF && \
-    -DTBB_TEST=OFF && \
+    emcmake cmake .. \
+    -DCMAKE_CXX_COMPILER=em++ \
+    -DCMAKE_C_COMPILER=emcc \
+    -DTBB_STRICT=OFF \
+    -DCMAKE_CXX_FLAGS="-fwasm-exceptions -Wno-unused-command-line-argument" \
+    -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON \
+    -DBUILD_SHARED_LIBS=ON \
+    -DTBB_EXAMPLES=OFF \
+    -DTBB_TEST=OFF \
     -DEMSCRIPTEN_WITHOUT_PTHREAD=true && \
     cmake --build .
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,45 @@
+# Dockerfile
+FROM emscripten/emsdk:3.1.59
+
+# Set the working directory
+WORKDIR /app
+
+# Install necessary tools
+RUN apt-get update && apt-get install -y \
+    git \
+    cmake \
+    make
+
+# Clone the TinyStan repository
+RUN git clone https://github.com/WardBrian/tinystan.git
+
+# Clone the oneTBB library and checkout the specific commit
+RUN git clone https://github.com/oneapi-src/oneTBB.git && \
+    cd oneTBB && \
+    git checkout 4a87ca1
+
+# Build oneTBB with emscripten
+RUN mkdir oneTBB/build && cd oneTBB/build && \
+    emcmake cmake .. && \
+    -DCMAKE_CXX_COMPILER=em++ && \
+    -DCMAKE_C_COMPILER=emcc && \
+    -DTBB_STRICT=OFF && \
+    -DCMAKE_CXX_FLAGS="-fwasm-exceptions -Wno-unused-command-line-argument" && \
+    -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON && \
+    -DBUILD_SHARED_LIBS=ON && \
+    -DTBB_EXAMPLES=OFF && \
+    -DTBB_TEST=OFF && \
+    -DEMSCRIPTEN_WITHOUT_PTHREAD=true && \
+    cmake --build .
+
+# Copy the local configuration file for TinyStan
+COPY make/local /app/tinystan/make/local
+
+# Build the model
+RUN cd tinystan && \
+    echo "\n%.js : %.o $(TINYSTAN_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)\n\t$(LINK.cpp) -lm -o $(patsubst %.o, %.js, $(subst \\,/,$<)) $(subst \\,/,$*.o) $(TINYSTAN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)" >> Makefile && \
+    emmake make test_models/bernoulli/bernoulli.js -j2
+
+# Copy the built files to the desired location
+RUN cp tinystan/test_models/bernoulli/bernoulli.js src/tinystan && \
+    cp tinystan/test_models/bernoulli/bernoulli.wasm src/tinystan

--- a/docker/make/local
+++ b/docker/make/local
@@ -1,0 +1,13 @@
+makefile
+# use our wasm-friendly TBB, not Stan's vendored version
+TBB_INTERFACE_NEW=1
+TBB_INC=$(TBB_FROM_STEP_3)/include/ # CHANGE THIS
+TBB_LIB=$(TBB_BUILD_FOLDER_FROM_STEP_4) # CHANGE THIS
+LDFLAGS_TBB ?= -Wl,-L,"$(TBB_LIB)"
+LDLIBS_TBB ?= -ltbb
+# Functions we want. Can add more, with a prepended _, from tinystan.h
+EXPORTS=_malloc,_free,_tinystan_api_version,_tinystan_create_model,_tinystan_destroy_error,_tinystan_destroy_model,_tinystan_get_error_message,_tinystan_get_error_type,_tinystan_model_num_free_params,_tinystan_model_param_names,_tinystan_sample,_tinystan_separator_char,_tinystan_stan_version
+CXXFLAGS+=-fwasm-exceptions # could also uses -fexceptions which is more compatible, but slower
+CXXFLAGS+=-sEXIT_RUNTIME=1 -sALLOW_MEMORY_GROWTH=1
+CXXFLAGS+=-sEXPORTED_FUNCTIONS=$(EXPORTS)-sEXPORTED_RUNTIME_METHODS=stringToUTF8,getValue,UTF8ToString,lengthBytesUTF8
+CXXFLAGS+=-sMODULARIZE -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web

--- a/docker/make/local
+++ b/docker/make/local
@@ -1,12 +1,14 @@
 # use our wasm-friendly TBB, not Stan's vendored version
 TBB_INTERFACE_NEW=1
-TBB_INC=$(TBB_FROM_STEP_3)/include/ # CHANGE THIS
-TBB_LIB=$(TBB_BUILD_FOLDER_FROM_STEP_4) # CHANGE THIS
+# TBB_INC=$(TBB_FROM_STEP_3)/include/ # CHANGE THIS
+TBB_INC=/app/oneTBB/include/
+# TBB_LIB=$(TBB_BUILD_FOLDER_FROM_STEP_4) # CHANGE THIS
+TBB_LIB=/app/oneTBB/build/clang_19.0_cxx11_32_relwithdebinfo/
 LDFLAGS_TBB ?= -Wl,-L,"$(TBB_LIB)"
 LDLIBS_TBB ?= -ltbb
 # Functions we want. Can add more, with a prepended _, from tinystan.h
 EXPORTS=_malloc,_free,_tinystan_api_version,_tinystan_create_model,_tinystan_destroy_error,_tinystan_destroy_model,_tinystan_get_error_message,_tinystan_get_error_type,_tinystan_model_num_free_params,_tinystan_model_param_names,_tinystan_sample,_tinystan_separator_char,_tinystan_stan_version
 CXXFLAGS+=-fwasm-exceptions # could also uses -fexceptions which is more compatible, but slower
 CXXFLAGS+=-sEXIT_RUNTIME=1 -sALLOW_MEMORY_GROWTH=1
-CXXFLAGS+=-sEXPORTED_FUNCTIONS=$(EXPORTS)-sEXPORTED_RUNTIME_METHODS=stringToUTF8,getValue,UTF8ToString,lengthBytesUTF8
+CXXFLAGS+=-sEXPORTED_FUNCTIONS=$(EXPORTS) -sEXPORTED_RUNTIME_METHODS=stringToUTF8,getValue,UTF8ToString,lengthBytesUTF8
 CXXFLAGS+=-sMODULARIZE -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web

--- a/docker/make/local
+++ b/docker/make/local
@@ -1,4 +1,3 @@
-makefile
 # use our wasm-friendly TBB, not Stan's vendored version
 TBB_INTERFACE_NEW=1
 TBB_INC=$(TBB_FROM_STEP_3)/include/ # CHANGE THIS


### PR DESCRIPTION
@WardBrian @jsoules

In preparation for creating a web service that could accept a stan program and return the wasm blob needed by stan-web-demo, I've drafted a docker image based on the instructions in DEVELOPMENT.md

```bash
cd docker
docker build .
```

I run into the following error and was wondering if you could take a look

```bash
[+] Building 18.1s (10/13)                                                                                                  docker:default
 => [internal] load .dockerignore                                                                                                     0.0s
 => => transferring context: 2B                                                                                                       0.0s
 => [internal] load build definition from Dockerfile                                                                                  0.0s
 => => transferring dockerfile: 1.58kB                                                                                                0.0s
 => [internal] load metadata for docker.io/emscripten/emsdk:3.1.59                                                                    0.0s
 => [1/9] FROM docker.io/emscripten/emsdk:3.1.59                                                                                      0.0s
 => [internal] load build context                                                                                                     0.1s
 => => transferring context: 1.02kB                                                                                                   0.0s
 => CACHED [2/9] WORKDIR /app                                                                                                         0.0s
 => CACHED [3/9] RUN apt-get update && apt-get install -y     git     cmake     make                                                  0.0s
 => CACHED [4/9] RUN git clone https://github.com/WardBrian/tinystan.git                                                              0.0s
 => CACHED [5/9] RUN git clone https://github.com/oneapi-src/oneTBB.git &&     cd oneTBB &&     git checkout 4a87ca1                  0.0s
 => ERROR [6/9] RUN mkdir oneTBB/build && cd oneTBB/build &&     emcmake cmake .. &&     -DCMAKE_CXX_COMPILER=em++ &&     -DCMAKE_C  17.9s
------                                                                                                                                     
 > [6/9] RUN mkdir oneTBB/build && cd oneTBB/build &&     emcmake cmake .. &&     -DCMAKE_CXX_COMPILER=em++ &&     -DCMAKE_C_COMPILER=emcc &&     -DTBB_STRICT=OFF &&     -DCMAKE_CXX_FLAGS="-fwasm-exceptions -Wno-unused-command-line-argument" &&     -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON &&     -DBUILD_SHARED_LIBS=ON &&     -DTBB_EXAMPLES=OFF &&     -DTBB_TEST=OFF &&     -DEMSCRIPTEN_WITHOUT_PTHREAD=true &&     cmake --build .:                                                                                                                             
0.313 configure: cmake .. -DCMAKE_TOOLCHAIN_FILE=/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -DCMAKE_CROSSCOMPILING_EMULATOR=/emsdk/node/16.20.0_64bit/bin/node
0.523 -- CMAKE_BUILD_TYPE is not specified. Using default: RelWithDebInfo
0.524 -- Found Threads: TRUE  
0.528 -- Looking for getcontext
1.028 -- Looking for getcontext - not found
17.19 -- IPO enabled
17.20 CMake Warning (dev) at src/tbb/CMakeLists.txt:15 (add_library):
17.20   ADD_LIBRARY called with SHARED option but the target platform does not
17.20   support dynamic linking.  Building a STATIC library instead.  This may lead
17.20   to problems.
17.20 This warning is for project developers.  Use -Wno-dev to suppress it.
17.20 
17.20 CMake Warning (dev) at src/tbbmalloc/CMakeLists.txt:15 (add_library):
17.20   ADD_LIBRARY called with SHARED option but the target platform does not
17.20   support dynamic linking.  Building a STATIC library instead.  This may lead
17.20   to problems.
17.20 This warning is for project developers.  Use -Wno-dev to suppress it.
17.20 
17.23 CMake Warning (dev) at src/tbbmalloc_proxy/CMakeLists.txt:19 (add_library):
17.23   ADD_LIBRARY called with SHARED option but the target platform does not
17.23   support dynamic linking.  Building a STATIC library instead.  This may lead
17.23   to problems.
17.23 This warning is for project developers.  Use -Wno-dev to suppress it.
17.23 
17.23 -- HWLOC target HWLOC::hwloc_1_11 doesn't exist. The tbbbind target cannot be created
17.23 -- HWLOC target HWLOC::hwloc_2 doesn't exist. The tbbbind_2_0 target cannot be created
17.23 -- HWLOC target HWLOC::hwloc_2_5 doesn't exist. The tbbbind_2_5 target cannot be created
17.24 -- Performing Test LINKER_HAS_NO_AS_NEEDED
17.62 -- Performing Test LINKER_HAS_NO_AS_NEEDED - Failed
17.63 CMake Warning (dev) at test/CMakeLists.txt:123 (add_library):
17.63   ADD_LIBRARY called with SHARED option but the target platform does not
17.63   support dynamic linking.  Building a STATIC library instead.  This may lead
17.63   to problems.
17.63 Call Stack (most recent call first):
17.63   test/CMakeLists.txt:645 (tbb_add_lib_test)
17.63 This warning is for project developers.  Use -Wno-dev to suppress it.
17.63 
17.64 -- Configuring done
17.79 -- Generating done
17.80 -- Build files have been written to: /app/oneTBB/build
17.81 /bin/sh: 1: -DCMAKE_CXX_COMPILER=em++: not found
------
Dockerfile:22
--------------------
  21 |     # Build oneTBB with emscripten
  22 | >>> RUN mkdir oneTBB/build && cd oneTBB/build && \
  23 | >>>     emcmake cmake .. && \
  24 | >>>     -DCMAKE_CXX_COMPILER=em++ && \
  25 | >>>     -DCMAKE_C_COMPILER=emcc && \
  26 | >>>     -DTBB_STRICT=OFF && \
  27 | >>>     -DCMAKE_CXX_FLAGS="-fwasm-exceptions -Wno-unused-command-line-argument" && \
  28 | >>>     -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON && \
  29 | >>>     -DBUILD_SHARED_LIBS=ON && \
  30 | >>>     -DTBB_EXAMPLES=OFF && \
  31 | >>>     -DTBB_TEST=OFF && \
  32 | >>>     -DEMSCRIPTEN_WITHOUT_PTHREAD=true && \
  33 | >>>     cmake --build .
  34 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c mkdir oneTBB/build && cd oneTBB/build &&     emcmake cmake .. &&     -DCMAKE_CXX_COMPILER=em++ &&     -DCMAKE_C_COMPILER=emcc &&     -DTBB_STRICT=OFF &&     -DCMAKE_CXX_FLAGS=\"-fwasm-exceptions -Wno-unused-command-line-argument\" &&     -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON &&     -DBUILD_SHARED_LIBS=ON &&     -DTBB_EXAMPLES=OFF &&     -DTBB_TEST=OFF &&     -DEMSCRIPTEN_WITHOUT_PTHREAD=true &&     cmake --build ." did not complete successfully: exit code: 127
```