### PR TITLE
stan-wasm-server: proof of concept

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+extend-ignore = E124,E128,E301,E302,E305,E402,E501,E261,W504
+# E124: closing bracket does not match visual indentation
+# E128: continuation line under-indented for visual indent
+# E301: expected 1 blank line, found 0
+# E302: expected 2 blank lines, found 1
+# E305: expected 2 blank lines after class or function definition, found 1
+# E402: module level import not at top of file
+# E501: line too long (82 > 79 characters)
+# E261: at least two spaces before inline comment
+# W504: line break after binary operator

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,5 +44,14 @@ RUN cd tinystan && \
     emmake make test_models/bernoulli/bernoulli.js -j2 && \
     emstrip test_models/bernoulli/bernoulli.wasm
 
-FROM scratch
-COPY --from=builder /app/tinystan/test_models/bernoulli/bernoulli.js /app/tinystan/test_models/bernoulli/bernoulli.wasm /
+# FROM scratch
+# COPY --from=builder /app/tinystan/test_models/bernoulli/bernoulli.js /app/tinystan/test_models/bernoulli/bernoulli.wasm /
+
+RUN pip install fastapi
+RUN pip install uvicorn
+COPY stan-wasm-server /stan-wasm-server
+WORKDIR /stan-wasm-server
+
+ENV SWS_PASSCODE=1234
+ENV TINYSTAN_DIR=/app/tinystan
+CMD ["bash", "run.sh"]

--- a/docker/build_and_push.sh
+++ b/docker/build_and_push.sh
@@ -1,0 +1,9 @@
+IMAGE_NAME=magland/stan-wasm-server
+
+docker build -t $IMAGE_NAME .
+
+# prompt user to continue
+echo "Press any key to continue to push to docker hub..."
+read -n 1 -s
+
+docker push $IMAGE_NAME

--- a/docker/make/local
+++ b/docker/make/local
@@ -10,3 +10,4 @@ CXXFLAGS+=-fwasm-exceptions # could also uses -fexceptions which is more compati
 CXXFLAGS+=-sEXIT_RUNTIME=1 -sALLOW_MEMORY_GROWTH=1
 CXXFLAGS+=-sEXPORTED_FUNCTIONS=$(EXPORTS) -sEXPORTED_RUNTIME_METHODS=stringToUTF8,getValue,UTF8ToString,lengthBytesUTF8
 CXXFLAGS+=-sMODULARIZE -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web
+CXXFLAGS+=-g

--- a/docker/stan-wasm-server/main.py
+++ b/docker/stan-wasm-server/main.py
@@ -1,0 +1,229 @@
+from random import choice
+import time
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi import Header
+from fastapi import Body
+import os
+import subprocess
+
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+SWS_PASSCODE = os.environ.get("SWS_PASSCODE", "")
+if not SWS_PASSCODE:
+    raise ValueError("SWS_PASSCODE environment variable not set")
+
+TINYSTAN_DIR = os.environ.get("TINYSTAN_DIR", "")
+if not TINYSTAN_DIR:
+    raise ValueError("TINYSTAN_DIR environment variable not set")
+
+
+# probe
+@app.get("/probe")
+async def probe():
+    return {"status": "ok"}
+
+
+@app.post("/job/initiate")
+async def initiate_job(authorization: str = Header(None)):
+    # Generate a unique job ID
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Passcode not provided")
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+    passcode = authorization.split(" ")[1]
+    if not _passcode_is_valid(passcode):
+        raise HTTPException(status_code=401, detail="Invalid passcode")
+    job_id = _create_job_id()
+    job_dir = _get_job_dir(job_id)
+    os.makedirs(job_dir, exist_ok=True)
+    with open(f"{job_dir}/status.txt", "w") as status_file:
+        status_file.write("initiated")
+    return {"job_id": job_id, "status": "initiated"}
+
+
+@app.get("/job/{job_id}/status")
+async def job_status(job_id: str):
+    if not _is_valid_job_id(job_id):
+        raise HTTPException(status_code=400, detail="Invalid job ID")
+    job_dir = _get_job_dir(job_id)
+    if not os.path.isdir(job_dir):
+        raise HTTPException(status_code=404, detail="Job not found")
+    with open(f"{job_dir}/status.txt", "r") as status_file:
+        status = status_file.read()
+    return {"job_id": job_id, "status": status}
+
+
+@app.post("/job/{job_id}/upload/{filename}")
+async def upload_file(job_id: str, filename: str, data: bytes = Body(...)):
+    if not _is_valid_job_id(job_id):
+        raise HTTPException(status_code=400, detail="Invalid job ID")
+    if "/" in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+    if filename not in ["main.stan"]:
+        raise HTTPException(
+            status_code=400, detail=f"Not allowed to upload a file with name {filename}"
+        )
+    # check that the file is not too large
+    if len(data) > 1024 * 1024 * 10:
+        raise HTTPException(status_code=400, detail="File too large")
+    job_dir = _get_job_dir(job_id)
+    if not os.path.isdir(job_dir):
+        raise HTTPException(status_code=404, detail="Job not found")
+    # get status
+    with open(f"{job_dir}/status.txt", "r") as status_file:
+        status = status_file.read()
+    if status != "initiated":
+        raise HTTPException(
+            status_code=400, detail=f"Cannot upload files to a job with status {status}"
+        )
+    file_location = f"{job_dir}/{filename}"
+    with open(file_location, "wb") as file_object:
+        file_object.write(data)
+    return {"success": True}
+
+
+@app.get("/job/{job_id}/download/{filename}")
+async def download_file(job_id: str, filename: str):
+    if not _is_valid_job_id(job_id):
+        raise HTTPException(status_code=400, detail="Invalid job ID")
+    # make sure filename is not a path, just a name
+    if "/" in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+    if filename not in ["main.js", "main.wasm"]:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Not allowed to download a file with name {filename}",
+        )
+    job_dir = _get_job_dir(job_id)
+    if not os.path.isdir(job_dir):
+        raise HTTPException(status_code=404, detail="Job not found")
+    file_location = f"{job_dir}/{filename}"
+    if not os.path.isfile(file_location):
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(file_location)
+
+
+# Run the job
+@app.post("/job/{job_id}/run")
+async def run_job(job_id: str):
+    if not _is_valid_job_id(job_id):
+        raise HTTPException(status_code=400, detail="Invalid job ID")
+    job_dir = _get_job_dir(job_id)
+    if not os.path.isdir(job_dir):
+        raise HTTPException(status_code=404, detail="Job not found")
+    # get the status
+    with open(f"{job_dir}/status.txt", "r") as status_file:
+        status = status_file.read()
+    if status != "initiated":
+        raise HTTPException(
+            status_code=400, detail=f"Cannot run a job with status {status}"
+        )
+    with open(f"{job_dir}/status.txt", "w") as status_file:
+        status_file.write("running")
+    main_fname = f"{job_dir}/main.stan"
+    stan_program_hash = _compute_stan_program_hash(main_fname)
+    model_dir = f'{TINYSTAN_DIR}/test_models/{stan_program_hash}'
+    if not os.path.exists(os.path.dirname(model_dir)):
+        os.makedirs(os.path.dirname(model_dir))
+    if os.path.exists(model_dir):
+        if os.path.exists(f'{model_dir}/main.js') and os.path.exists(f'{model_dir}/main.wasm'):
+            os.system(f"cp {model_dir}/main.js {job_dir}/main.js")
+            os.system(f"cp {model_dir}/main.wasm {job_dir}/main.wasm")
+            with open(f"{job_dir}/status.txt", "w") as status_file:
+                status_file.write("completed")
+            return {"job_id": job_id, "status": "completed"}
+        else:
+            if os.path.exists(f'{model_dir}/running.txt'):
+                elapsed_since_modified = time.time() - os.path.getmtime(model_dir)
+                if elapsed_since_modified < 60 * 5:
+                    # we'll assume that the model is being compiled
+                    with open(f"{job_dir}/status.txt", "w") as status_file:
+                        status_file.write("running")
+                    return {"job_id": job_id, "status": "running"}
+                else:
+                    # we'll assume that the model failed
+                    os.system(f"rm -rf {model_dir}")
+            else:
+                os.system(f"rm -rf {model_dir}")
+    os.makedirs(model_dir, exist_ok=True)
+    with open(f'{model_dir}/running.txt', 'w') as running_file:
+        running_file.write('running')
+    try:
+        run_sh_text = _create_run_sh_text(job_dir=job_dir, model_dir=model_dir, tinystan_dir=TINYSTAN_DIR)
+        with open(f"{job_dir}/run.sh", "w") as run_sh_file:
+            run_sh_file.write(run_sh_text)
+        process = subprocess.run(f"bash {job_dir}/run.sh", shell=True, check=False)
+        if process.returncode != 0:
+            raise Exception(f'Failed to compile model: exit code {process.returncode}')
+        if not os.path.exists(f'{model_dir}/main.js') or not os.path.exists(f'{model_dir}/main.wasm'):
+            raise Exception('Failed to compile model: missing main.js or main.wasm')
+    except Exception as e:
+        with open(f"{job_dir}/log.txt", "w") as log_file:
+            log_file.write(str(e))
+        with open(f"{job_dir}/status.txt", "w") as status_file:
+            status_file.write("failed")
+        return {"job_id": job_id, "status": "failed"}
+    finally:
+        os.remove(f'{model_dir}/running.txt')
+    with open(f"{job_dir}/status.txt", "w") as status_file:
+        status_file.write("completed")
+    return {"job_id": job_id, "status": "completed"}
+
+
+def _compute_stan_program_hash(fname: str):
+    import hashlib
+
+    with open(fname, "r") as f:
+        stan_program = f.read()
+    # TODO: replace stan_program with a canonical form
+    return hashlib.sha1(stan_program.encode()).hexdigest()
+
+
+choices = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def _create_job_id():
+    length_of_id = 20
+    return "".join(choice(choices) for _ in range(length_of_id))
+
+
+def _is_valid_job_id(job_id: str):
+    if len(job_id) < 12:
+        return False
+    if len(job_id) > 40:
+        return False
+    if not all(c in choices for c in job_id):
+        return False
+    return True
+
+
+def _get_job_dir(job_id: str):
+    return f"jobs/{job_id}"
+
+
+def _create_run_sh_text(*, job_dir: str, model_dir: str, tinystan_dir: str):
+    ret = f"""#!/bin/bash
+
+cp {job_dir}/main.stan {model_dir}/main.stan
+
+# move to the tinystan directory
+cd {tinystan_dir}
+emmake make {model_dir}/main.js -j2 && \
+emstrip {model_dir}/main.wasm
+"""
+    return ret
+
+
+def _passcode_is_valid(passcode: str):
+    return passcode == SWS_PASSCODE

--- a/docker/stan-wasm-server/main.py
+++ b/docker/stan-wasm-server/main.py
@@ -168,6 +168,8 @@ async def run_job(job_id: str):
             raise Exception(f'Failed to compile model: exit code {process.returncode}')
         if not os.path.exists(f'{model_dir}/main.js') or not os.path.exists(f'{model_dir}/main.wasm'):
             raise Exception('Failed to compile model: missing main.js or main.wasm')
+        os.system(f"cp {model_dir}/main.js {job_dir}/main.js")
+        os.system(f"cp {model_dir}/main.wasm {job_dir}/main.wasm")
     except Exception as e:
         with open(f"{job_dir}/log.txt", "w") as log_file:
             log_file.write(str(e))

--- a/docker/stan-wasm-server/run.sh
+++ b/docker/stan-wasm-server/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -ex
+
+uvicorn main:app --host 0.0.0.0 --port 8080

--- a/stan-web-demo/src/App.tsx
+++ b/stan-web-demo/src/App.tsx
@@ -12,6 +12,10 @@ import Footer from "./components/Footer";
 
 import StanModel from "./tinystan";
 import createModule from "./tinystan/bernoulli.js";
+import TestComponent from "./TestComponent.js";
+
+const queryParams = new URLSearchParams(window.location.search);
+const testMode = queryParams.get("test") === "1";
 
 const App = () => {
   const [stanCode, setStanCode] = useState("// Loading Stan source code...");
@@ -38,6 +42,12 @@ const App = () => {
       setStanVersion(`Stan Version ${model.stanVersion()}`);
     });
   }, []);
+
+  if (testMode) {
+    return (
+      <TestComponent />
+    )
+  }
 
   return (
     <>

--- a/stan-web-demo/src/TestComponent.tsx
+++ b/stan-web-demo/src/TestComponent.tsx
@@ -1,0 +1,119 @@
+import { FunctionComponent, useCallback, useState } from "react";
+
+const TestComponent: FunctionComponent = () => {
+    const [statusMessage, setStatusMessage] = useState<string>("");
+    const handleClick = useCallback(async () => {
+        setStatusMessage("Initiating job...");
+        const initiateJobUrl = "http://localhost:8083/job/initiate"
+        // post
+        const a = await fetch(initiateJobUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": "Bearer 1234"
+            }
+        });
+        if (!a.ok) {
+            setStatusMessage(`Failed to initiate job: ${a.statusText}`);
+            return;
+        }
+        const resp = await a.json();
+        const job_id = resp.job_id;
+        if (!job_id) {
+            setStatusMessage(`Failed to initiate job: ${JSON.stringify(resp)}`);
+            return;
+        }
+
+        setStatusMessage(`Job initiated: ${job_id}`);
+        const uploadFileUrl = `http://localhost:8083/job/${job_id}/upload/main.stan`;
+        const stanProgram = getStanProgram();
+        const b = await fetch(uploadFileUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "text/plain",
+            },
+            body: stanProgram
+        });
+        if (!b.ok) {
+            setStatusMessage(`Failed to upload file: ${b.statusText}`);
+            return;
+        }
+        setStatusMessage("File uploaded successfully");
+
+        setStatusMessage("Running job...");
+        const runJobUrl = `http://localhost:8083/job/${job_id}/run`;
+        const c = await fetch(runJobUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            }
+        });
+        if (!c.ok) {
+            setStatusMessage(`Failed to run job: ${c.statusText}`);
+            return;
+        }
+        const respC = await c.json();
+        if (respC.status === 'completed') {
+            setStatusMessage("Job completed successfully");
+        }
+        else {
+            setStatusMessage(`Job failed: ${JSON.stringify(respC)}`);
+            return;
+        }
+
+        const downloadMainJsUrl = `http://localhost:8083/job/${job_id}/download/main.js`;
+        const downloadMainWasmUrl = `http://localhost:8083/job/${job_id}/download/main.wasm`;
+        setStatusMessage("Downloading main.js");
+        const d = await fetch(downloadMainJsUrl);
+        if (!d.ok) {
+            setStatusMessage(`Failed to download main.js: ${d.statusText}`);
+            return;
+        }
+        const mainJs = await d.text();
+        setStatusMessage("Downloading main.wasm");
+        const e = await fetch(downloadMainWasmUrl);
+        if (!e.ok) {
+            setStatusMessage(`Failed to download main.wasm: ${e.statusText}`);
+            return;
+        }
+        const mainWasm = await e.arrayBuffer();
+
+        console.info('=========================================== main.js ===========================================');
+        console.info(mainJs);
+        console.info('=========================================== main.wasm ===========================================');
+        console.info(mainWasm);
+        setStatusMessage("Created main.js and main.wasm files. See the browser console for more details.");
+
+    }, []);
+    return (
+        <div>
+            <h1>WASM Compile Test</h1>
+            <pre>Instructions:</pre>
+            <pre>Run the docker image:</pre>
+
+            <pre>cd docker</pre>
+            <pre>docker build -t stan-web-demo .</pre>
+            <pre>docker run -p 8083:8080 -it stan-web-demo</pre>
+            <button onClick={handleClick}>Then click me</button>
+            <p>{statusMessage}</p>
+        </div>
+    );
+}
+
+const getStanProgram = () => (`
+data {
+    int<lower=0> N;
+    vector[N] x;
+    vector[N] y;
+}
+parameters {
+    real alpha;
+    real beta;
+    real<lower=0> sigma;
+}
+model {
+    y ~ normal(alpha + beta * x, sigma);
+}
+`)
+
+export default TestComponent;

--- a/stan-web-demo/src/TestComponent.tsx
+++ b/stan-web-demo/src/TestComponent.tsx
@@ -91,7 +91,7 @@ const TestComponent: FunctionComponent = () => {
             <pre>Instructions:</pre>
             <pre>Run the docker container for the server:</pre>
 
-            <pre>docker run -p 8083:8000 -it magland/stan-wasm-server:latest</pre>
+            <pre>docker run -p 8083:8080 -it magland/stan-wasm-server:latest</pre>
 
             <button onClick={handleClick}>Then click me</button>
             <p>{statusMessage}</p>

--- a/stan-web-demo/src/TestComponent.tsx
+++ b/stan-web-demo/src/TestComponent.tsx
@@ -89,11 +89,10 @@ const TestComponent: FunctionComponent = () => {
         <div>
             <h1>WASM Compile Test</h1>
             <pre>Instructions:</pre>
-            <pre>Run the docker image:</pre>
+            <pre>Run the docker container for the server:</pre>
 
-            <pre>cd docker</pre>
-            <pre>docker build -t stan-web-demo .</pre>
-            <pre>docker run -p 8083:8080 -it stan-web-demo</pre>
+            <pre>docker run -p 8083:8000 -it magland/stan-wasm-server:latest</pre>
+
             <button onClick={handleClick}>Then click me</button>
             <p>{statusMessage}</p>
         </div>


### PR DESCRIPTION
Here's a proof of concept for a dockerized server that can compile stan programs into wasm

Instructions

Start the web UI with test=1 query parameter. For example http://127.0.0.1:5173/stan-web-demo/?test=1

Then follow the instructions on the page which will tell you to build and run the docker image listening on port 8083

Click the button to try it... and keep you eye on the terminal running the docker container.

The resulting .js and .wasm will be shown in the browser dev console to prove that it "worked".

See the source code for the hard-coded stan program used.

The results are cached on the server until you restart the docker container.

@WardBrian @jsoules 